### PR TITLE
Fix #35: consitency spec and logs

### DIFF
--- a/nopol/src/main/java/fr/inria/lille/commons/trace/SpecificationTestCasesListener.java
+++ b/nopol/src/main/java/fr/inria/lille/commons/trace/SpecificationTestCasesListener.java
@@ -1,5 +1,7 @@
 package fr.inria.lille.commons.trace;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import xxl.java.container.classic.MetaList;
 import xxl.java.container.classic.MetaMap;
 import xxl.java.container.classic.MetaSet;
@@ -8,79 +10,103 @@ import xxl.java.junit.TestCasesListener;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
 public class SpecificationTestCasesListener<T> extends TestCasesListener {
 
-    public SpecificationTestCasesListener(RuntimeValues<T> runtimeValues) {
-        this.runtimeValues = runtimeValues;
-        consistentInputs = MetaMap.newHashMap();
-        inconsistentInputs = MetaSet.newHashSet();
-    }
+	private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    @Override
-    protected void processBeforeRun() {
-        runtimeValues().enable();
-    }
+	private RuntimeValues<T> runtimeValues;
+	private Map<Map<String, Object>, T> consistentInputs;
+	private Collection<Map<String, Object>> inconsistentInputs;
+	private Set<String> keys;
 
-    @Override
-    protected void processTestStarted(TestCase testCase) {
-        runtimeValues().reset();
-    }
+	public SpecificationTestCasesListener(RuntimeValues<T> runtimeValues) {
+		this.runtimeValues = runtimeValues;
+		this.consistentInputs = MetaMap.newHashMap();
+		this.inconsistentInputs = MetaSet.newHashSet();
+		this.keys = null;
+	}
 
-    @Override
-    protected void processSuccessfulRun(TestCase testCase) {
-        if (!runtimeValues().isEmpty()) {
-            // logDebug(logger(), "Collecting specifications from " + testCase);
-            for (Specification<T> specification : runtimeValues().specifications()) {
-                T output = specification.output();
-                Map<String, Object> inputs = specification.inputs();
-                if (consistencyCheck(inputs, output)) {
-                    consistentInputs().put(inputs, output);
-                }
-            }
-        }
-    }
+	@Override
+	protected void processBeforeRun() {
+		runtimeValues().enable();
+	}
 
-    private boolean consistencyCheck(Map<String, Object> inputs, T output) {
-        if (!inconsistentInputs().contains(inputs)) {
-            T reference = consistentInputs().get(inputs);
-            if (reference == null || output.equals(reference)) {
-                return true;
-            } else {
-                consistentInputs().remove(inputs);
-                inconsistentInputs().add(inputs);
-                // logWarning(logger(), "Inconsistent input found when collecting specifications");
-            }
-        }
-        return false;
-    }
+	@Override
+	protected void processTestStarted(TestCase testCase) {
+		runtimeValues().reset();
+	}
 
-    @Override
-    protected void processAfterRun() {
-        runtimeValues().disable();
-    }
+	@Override
+	protected void processSuccessfulRun(TestCase testCase) {
+		if (!runtimeValues().isEmpty()) {
+			// logDebug(logger(), "Collecting specifications from " + testCase);
+			for (Specification<T> specification : runtimeValues().specifications()) {
+				T output = specification.output();
+				Map<String, Object> inputs = specification.inputs();
+				addToSpec(inputs, output);
+			}
+		}
+	}
 
-    public Collection<Specification<T>> specifications() {
-        Collection<Specification<T>> specifications = MetaList.newLinkedList();
-        for (Map<String, Object> input : consistentInputs().keySet()) {
-            specifications.add(new Specification<T>(input, consistentInputs().get(input)));
-        }
-        return specifications;
-    }
 
-    protected RuntimeValues<T> runtimeValues() {
-        return runtimeValues;
-    }
+	private void addToSpec(Map<String, Object> inputs, T output) {
+		T reference = consistentInputs().get(inputs);
 
-    protected Map<Map<String, Object>, T> consistentInputs() {
-        return consistentInputs;
-    }
+		if (consistentInputs().size() == 0) {
+			consistentInputs().put(inputs, output);
+			this.keys = inputs.keySet();
+			return;
+		}
 
-    protected Collection<Map<String, Object>> inconsistentInputs() {
-        return inconsistentInputs;
-    }
+		if (reference == null && this.keys.equals(inputs.keySet())) {
+			// no such spec so far
+			consistentInputs().put(inputs, output);
+			return;
+		}
 
-    private RuntimeValues<T> runtimeValues;
-    private Map<Map<String, Object>, T> consistentInputs;
-    private Collection<Map<String, Object>> inconsistentInputs;
+		if (output.equals(reference)) {
+			this.logger.warn("You may have some redundant test: same input and same outcome, only one will be used: discarded.");// case 3
+			// already there, we don't duplicate the specification line which would slow SMT afterwards
+			return;
+		}
+
+		// here we have two different outcomes for the same input value
+		// it's a logical contradiction
+		// we discard it
+		this.inconsistentInputs.add(inputs);
+		if (!this.keys.equals(inputs.keySet())) {
+			this.logger.debug("Malformed problems: the same input value has different outcome: discarded.");// case 2
+			consistentInputs().remove(inputs);
+		} else {
+			this.logger.debug("Inconsistent specification: same input with same outcome, the condition can be flipped with no impact: discarded.");// case 1
+		}
+	}
+
+	@Override
+	protected void processAfterRun() {
+		runtimeValues().disable();
+	}
+
+	public Collection<Specification<T>> specifications() {
+		Collection<Specification<T>> specifications = MetaList.newLinkedList();
+		for (Map<String, Object> input : consistentInputs().keySet()) {
+			specifications.add(new Specification<T>(input, consistentInputs().get(input)));
+		}
+		return specifications;
+	}
+
+	protected RuntimeValues<T> runtimeValues() {
+		return runtimeValues;
+	}
+
+	protected Map<Map<String, Object>, T> consistentInputs() {
+		return consistentInputs;
+	}
+
+	protected Collection<Map<String, Object>> inconsistentInputs() {
+		return inconsistentInputs;
+	}
+
 }

--- a/nopol/src/main/java/fr/inria/lille/commons/trace/SpecificationTestCasesListener.java
+++ b/nopol/src/main/java/fr/inria/lille/commons/trace/SpecificationTestCasesListener.java
@@ -67,7 +67,8 @@ public class SpecificationTestCasesListener<T> extends TestCasesListener {
 		}
 
 		if (output.equals(reference) && this.keys.equals(inputs.keySet())) {
-			this.logger.warn("You may have some redundant test: same input and same outcome, only one will be used: discarded.");// case 3
+			this.logger.warn("You may have some redundant test: same input and same outcome: inputs={} : output={}.", inputs, output);// case 3
+			this.logger.warn("Only one will be used: discarded.");// case 3
 			// already there, we don't duplicate the specification line which would slow SMT afterwards
 			return;
 		}
@@ -77,10 +78,10 @@ public class SpecificationTestCasesListener<T> extends TestCasesListener {
 		// we discard it
 		this.inconsistentInputs.add(inputs);
 		if (!this.keys.equals(inputs.keySet())) {
-			this.logger.debug("Malformed problems: the same input value has different outcome: discarded.");// case 2
+			this.logger.debug("Ill-formed problem: not the input variables in input={} reference={}", inputs, this.keys);// case 2
 			consistentInputs().remove(inputs);
 		} else {
-			this.logger.debug("Inconsistent specification: same input with same outcome, the condition can be flipped with no impact: discarded.");// case 1
+			this.logger.debug("Same input with different outcome, logical contradiction, discarding the second one {}, {}, {}", inputs, consistentInputs.get(inputs), output);// case 1
 		}
 	}
 

--- a/nopol/src/main/java/fr/inria/lille/commons/trace/SpecificationTestCasesListener.java
+++ b/nopol/src/main/java/fr/inria/lille/commons/trace/SpecificationTestCasesListener.java
@@ -66,7 +66,7 @@ public class SpecificationTestCasesListener<T> extends TestCasesListener {
 			return;
 		}
 
-		if (output.equals(reference)) {
+		if (output.equals(reference) && this.keys.equals(inputs.keySet())) {
 			this.logger.warn("You may have some redundant test: same input and same outcome, only one will be used: discarded.");// case 3
 			// already there, we don't duplicate the specification line which would slow SMT afterwards
 			return;

--- a/nopol/src/main/java/fr/inria/lille/commons/trace/SpecificationTestCasesListener.java
+++ b/nopol/src/main/java/fr/inria/lille/commons/trace/SpecificationTestCasesListener.java
@@ -67,8 +67,7 @@ public class SpecificationTestCasesListener<T> extends TestCasesListener {
 		}
 
 		if (output.equals(reference) && this.keys.equals(inputs.keySet())) {
-			this.logger.warn("You may have some redundant test: same input and same outcome: inputs={} : output={}.", inputs, output);// case 3
-			this.logger.warn("Only one will be used: discarded.");// case 3
+			this.logger.warn("You have redundant tests: same input and same outcome, only one will be used to speed-up synthesis: discarded inputs={} : output={}.", inputs, output);// case 3
 			// already there, we don't duplicate the specification line which would slow SMT afterwards
 			return;
 		}
@@ -76,12 +75,13 @@ public class SpecificationTestCasesListener<T> extends TestCasesListener {
 		// here we have two different outcomes for the same input value
 		// it's a logical contradiction
 		// we discard it
-		this.inconsistentInputs.add(inputs);
 		if (!this.keys.equals(inputs.keySet())) {
 			this.logger.debug("Ill-formed problem: not the input variables in input={} reference={}", inputs, this.keys);// case 2
+			this.inconsistentInputs.add(inputs);
 			consistentInputs().remove(inputs);
 		} else {
-			this.logger.debug("Same input with different outcome, logical contradiction, discarding the second one {}, {}, {}", inputs, consistentInputs.get(inputs), output);// case 1
+			this.logger.debug("Same input with different outcome, logical contradiction, discarding the second one discarded={}, current output={}, reference output={}", inputs, output, consistentInputs.get(inputs));// case 1
+			this.inconsistentInputs.add(inputs);
 		}
 	}
 

--- a/nopol/src/main/java/fr/inria/lille/repair/nopol/synth/DefaultSynthesizer.java
+++ b/nopol/src/main/java/fr/inria/lille/repair/nopol/synth/DefaultSynthesizer.java
@@ -71,7 +71,7 @@ public final class DefaultSynthesizer<T> implements Synthesizer {
 		// there should be at least two sets of values, otherwise the patch would be "true" or "false"
 		int dataSize = data.size();
 		if (dataSize < 2) {
-			LoggerFactory.getLogger(this.getClass()).info("{} input values set(s). There are not enough tests for {} otherwise the patch would be \"true\" or \"false\"",
+			LoggerFactory.getLogger(this.getClass()).info("{} input values set(s). A trivial patch is \"true\" or \"false\"",
 					dataSize, sourceLocation);
 			return Collections.EMPTY_LIST;
 		}

--- a/nopol/src/main/java/fr/inria/lille/repair/nopol/synth/DefaultSynthesizer.java
+++ b/nopol/src/main/java/fr/inria/lille/repair/nopol/synth/DefaultSynthesizer.java
@@ -71,7 +71,7 @@ public final class DefaultSynthesizer<T> implements Synthesizer {
 		// there should be at least two sets of values, otherwise the patch would be "true" or "false"
 		int dataSize = data.size();
 		if (dataSize < 2) {
-			LoggerFactory.getLogger(this.getClass()).info("{} input values set(s). A trivial patch is \"true\" or \"false\"",
+			LoggerFactory.getLogger(this.getClass()).info("Not enough specifications: {}. A trivial patch is \"true\" or \"false\", please write new tests specifying {}.",
 					dataSize, sourceLocation);
 			return Collections.EMPTY_LIST;
 		}

--- a/nopol/src/test/java/fr/inria/lille/commons/trace/ValuesCollectorTest.java
+++ b/nopol/src/test/java/fr/inria/lille/commons/trace/ValuesCollectorTest.java
@@ -33,7 +33,7 @@ public class ValuesCollectorTest {
 
 	@Test
 	public final void adding_a_Collection_should_add_the_size_and_if_it_is_empty() {
-		
+
 		// GIVEN
 		String name = "collection";
 		Collection<?> value = asList(1, 2, 3);
@@ -42,7 +42,7 @@ public class ValuesCollectorTest {
 		RuntimeValues<?> runtimeValues = RuntimeValues.newInstance();
 		runtimeValues.enable();
 		runtimeValues.collectInput(name, value);
-		
+
 		// THEN
 		Map<String, ?> expected = MetaMap.newHashMap(asList(name + "!=null", name + ".size()", name + ".isEmpty()"), asList(true, value.size(), value.isEmpty()));
 		assertEquals(expected, runtimeValues.valueBuffer());
@@ -58,7 +58,7 @@ public class ValuesCollectorTest {
 		RuntimeValues<?> runtimeValues = RuntimeValues.newInstance();
 		runtimeValues.enable();
 		runtimeValues.collectInput(name, value);
-		
+
 		// THEN
 		Map<String, ?> expected = MetaMap.newHashMap(asList(name + "!=null", name + ".size()", name + ".isEmpty()"), asList(true, value.size(), value.isEmpty()));
 		assertEquals(expected, runtimeValues.valueBuffer());
@@ -84,7 +84,7 @@ public class ValuesCollectorTest {
 	public final void adding_an_array_should_add_the_length_also() {
 		// GIVEN
 		String name = "array";
-		int[] value = { 1, 2, 3 };
+		int[] value = {1, 2, 3};
 
 		// WHEN
 		RuntimeValues<?> runtimeValues = RuntimeValues.newInstance();
@@ -95,7 +95,7 @@ public class ValuesCollectorTest {
 		Map<String, ?> expected = MetaMap.newHashMap(asList(name + "!=null", name + ".length"), asList(true, value.length));
 		assertEquals(expected, runtimeValues.valueBuffer());
 	}
-	
+
 	@Test
 	public final void collectingNullObjectOnlyAddsNullCheck() {
 		// GIVEN
@@ -110,7 +110,7 @@ public class ValuesCollectorTest {
 		Map<String, ?> expected = MetaMap.newHashMap(asList(name + "!=null"), asList(false));
 		assertEquals(expected, runtimeValues.valueBuffer());
 	}
-	
+
 	@Test
 	public void collectingCharacters() {
 		// GIVEN
@@ -136,83 +136,111 @@ public class ValuesCollectorTest {
 		TestCase testB = TestCase.from("com.example", "testB", 2);
 		TestCase testC = TestCase.from("com.example", "testC", 3);
 		RuntimeValues<Boolean> runtimeValues = RuntimeValues.newInstance();
-		
+
 		Collection<Specification<Boolean>> specifications;
 		Collection<Map<String, Object>> inconsistencies;
-		Map<String, Object> otherValue = (Map) MetaMap.newHashMap(asList("c"), asList(3));
-		Map<String, Object> values = (Map) MetaMap.newHashMap(asList("a", "b"), asList(1, 2));
-		Specification<Boolean> consistent = new Specification<Boolean>(otherValue, true);
-		Specification<Boolean> inconsistent = new Specification<Boolean>(values, false);
+		Map<String, Object> values1 = (Map) MetaMap.newHashMap(asList("a", "b"), asList(1, 2));
+		Map<String, Object> values2 = (Map) MetaMap.newHashMap(asList("c"), asList(3));
+		Map<String, Object> values3 = (Map) MetaMap.newHashMap(asList("a", "b"), asList(23, 32));
+		Specification<Boolean> spec1 = new Specification<Boolean>(values1, true); // first specs
+		Specification<Boolean> spec2 = new Specification<Boolean>(values2, true); // different input set
+		Specification<Boolean> spec3 = new Specification<Boolean>(values3, false); // new specs
+		Specification<Boolean> spec4 = new Specification<Boolean>(values3, true); // same input, different outcome
+
 		SpecificationTestCasesListener<Boolean> listener = new SpecificationTestCasesListener<Boolean>(runtimeValues);
-		
+
+		/* The listener keeps states between run of test method: assertion step by step. */
+
+		/* One input set for one output: 1 spec and no inconsistency*/
+
 		listener.processBeforeRun();
 		listener.processTestStarted(testA);
-		runtimeValues.collectInput("a", values.get("a"));
-		runtimeValues.collectInput("b", values.get("b"));
-		runtimeValues.collectOutput(false);
+		runtimeValues.collectInput("a", values1.get("a"));
+		runtimeValues.collectInput("b", values1.get("b"));
+		runtimeValues.collectOutput(true);
 		runtimeValues.collectionEnds();
 		assertFalse(runtimeValues.isEmpty());
 		listener.processSuccessfulRun(testA);
 		specifications = listener.specifications();
 		assertEquals(1, specifications.size());
-		assertTrue(specifications.contains(inconsistent));
+		assertTrue(specifications.contains(spec1));
 		inconsistencies = listener.inconsistentInputs();
 		assertTrue(inconsistencies.isEmpty());
-		
+
+		 /* 2 input sets with different keys input: only keep the first input set: 1 spec and 1 inconsistency */
+
 		listener.processTestStarted(testB);
-		runtimeValues.collectInput("c", otherValue.get("c"));
-		runtimeValues.collectOutput(true);
-		runtimeValues.collectionEnds();
-		runtimeValues.collectInput("a", values.get("a"));
-		runtimeValues.collectInput("b", values.get("b"));
+		runtimeValues.collectInput("c", values2.get("c"));
 		runtimeValues.collectOutput(true);
 		runtimeValues.collectionEnds();
 		assertFalse(runtimeValues.isEmpty());
 		listener.processSuccessfulRun(testB);
 		specifications = listener.specifications();
 		assertEquals(1, specifications.size());
-//		assertTrue(specifications.contains(consistent));
+		assertTrue(specifications.contains(spec1));
 		inconsistencies = listener.inconsistentInputs();
-		assertEquals(2, inconsistencies.size());
-		assertTrue(inconsistencies.containsAll(asList(inconsistent.inputs())));
-		
+		assertEquals(1, inconsistencies.size());
+		assertTrue(inconsistencies.containsAll(asList(spec2.inputs())));
+
+		/* 2 different sets of input: keep both specifications: 2 spec and 1 inconsistency */
+
 		listener.processTestStarted(testC);
-		runtimeValues.collectInput("a", values.get("a"));
-		runtimeValues.collectInput("b", values.get("b"));
+		runtimeValues.collectInput("a", values3.get("a"));
+		runtimeValues.collectInput("b", values3.get("b"));
+		runtimeValues.collectOutput(false);
+		runtimeValues.collectionEnds();
+		assertFalse(runtimeValues.isEmpty());
+		listener.processSuccessfulRun(testC);
+		listener.processAfterRun();
+		specifications = listener.specifications();
+		assertEquals(2, specifications.size());
+		assertTrue(specifications.contains(spec1));
+		assertTrue(specifications.contains(spec3));
+		inconsistencies = listener.inconsistentInputs();
+		assertEquals(1, inconsistencies.size());
+		assertTrue(inconsistencies.containsAll(asList(spec2.inputs())));
+
+		/* Same input set, different outcome: discard the newest: 2 specs and 2 inconsistency */
+
+		listener.processTestStarted(testC);
+		runtimeValues.collectInput("a", values3.get("a"));
+		runtimeValues.collectInput("b", values3.get("b"));
 		runtimeValues.collectOutput(true);
 		runtimeValues.collectionEnds();
 		assertFalse(runtimeValues.isEmpty());
 		listener.processSuccessfulRun(testC);
 		listener.processAfterRun();
 		specifications = listener.specifications();
-		assertEquals(1, specifications.size());
-		//assertTrue(specifications.contains(consistent));
+		assertEquals(2, specifications.size());
+		assertTrue(specifications.contains(spec1));
+		assertTrue(specifications.contains(spec3));
 		inconsistencies = listener.inconsistentInputs();
 		assertEquals(2, inconsistencies.size());
-		assertTrue(inconsistencies.containsAll(asList(inconsistent.inputs())));
+		assertTrue(inconsistencies.containsAll(asList(spec2.inputs())));
+		assertTrue(inconsistencies.containsAll(asList(spec4.inputs())));
 	}
-	
+
 	@Test
 	public void reachedVariablesInExample1() {
 		CtElement element = elementInNopolProject(1, "index == 0");
 		testReachedVariableNames(element, "s",
-										  "index",
-										  "nopol_examples.nopol_example_1.NopolExample.this.index",
-										  "nopol_examples.nopol_example_1.NopolExample.s");
+				"index",
+				"nopol_examples.nopol_example_1.NopolExample.this.index",
+				"nopol_examples.nopol_example_1.NopolExample.s");
 	}
-	
+
 	@Test
 	public void reachedVariablesInExample2() {
 		CtElement element = elementInNopolProject(2, "(b - a) < 0");
 		testReachedVariableNames(element, "b", "a", "nopol_examples.nopol_example_2.NopolExample.this.fieldOfOuterClass");
 	}
-	
+
 	@Test
 	public void reachedVariablesInExample3() {
 		CtElement element = elementInNopolProject(3, "tmp != 0");
 		testReachedVariableNames(element, "a", "tmp");
 	}
-	
+
 	@Test
 	@Ignore
 	public void reachedVariablesInExample4() {
@@ -220,41 +248,41 @@ public class ValuesCollectorTest {
 		CtElement element = elementInNopolProject(4, "a = a.substring(1)");
 		testReachedVariableNames(element, "a", "initializedVariableShouldBeCollected", "otherInitializedVariableShouldBeCollected");
 	}
-	
+
 	@Test
 	public void reachedVariablesInExample5() {
 		CtElement element = elementInNopolProject(5, "r = -1");
 		testReachedVariableNames(element, "r", "a", "nopol_examples.nopol_example_5.NopolExample.this.unreachableFromInnterStaticClass");
 	}
-	
+
 	@Test
 	public void reachedVariablesInExample6() {
 		CtElement element = elementInNopolProject(6, "a > b");
 		testReachedVariableNames(element, "a", "b");
 	}
-	
+
 	@Test
 	@Ignore
 	public void reachedVariablesInsideConstructor() {
 		CtElement element = elementInNopolProject(1, "index = 2 * variableInsideConstructor");
 		testReachedVariableNames(element, "variableInsideConstructor");
 	}
-	
+
 	@Test
 	public void reachedVariableOfOuterClass() {
 		CtElement element = elementInNopolProject(2, "int result = 29");
 		testReachedVariableNames(element, "aBoolean",
-										  "nopol_examples.nopol_example_2.NopolExample.InnerNopolExample.this.fieldOfInnerClass",
-										  "nopol_examples.nopol_example_2.NopolExample.this.fieldOfOuterClass");
+				"nopol_examples.nopol_example_2.NopolExample.InnerNopolExample.this.fieldOfInnerClass",
+				"nopol_examples.nopol_example_2.NopolExample.this.fieldOfOuterClass");
 	}
-	
+
 	@Test
 	public void unreachedVariableInIfBranch() {
 		elementInNopolProject(3, "int unreachableVariable");
 		CtElement element = elementInNopolProject(3, "(!aBoolean) || (reachableVariable < 2)");
 		testReachedVariableNames(element, "aBoolean", "reachableVariable");
 	}
-	
+
 	@Test
 	@Ignore
 	public void reachedVariableInIfBranch() {
@@ -262,72 +290,72 @@ public class ValuesCollectorTest {
 		CtElement element = elementInNopolProject(3, "(!aBoolean) && (uninitializedReachableVariable < 2)");
 		testReachedVariableNames(element, "aBoolean", "uninitializedReachableVariable");
 	}
-	
+
 	@Test
 	public void unreachedVariableInInnerStaticClass() {
 		elementInNopolProject(5, "private java.lang.Integer unreachableFromInnterStaticClass;");
 		CtElement element = elementInNopolProject(5, "!(stringParameter.isEmpty())");
 		testReachedVariableNames(element, "stringParameter");
 	}
-	
+
 	@Test
 	public void fieldOfAnonymousClass() {
 		CtElement element = elementInNopolProject(2, "(fieldOfOuterClass) > (limit)");
 		testReachedVariableNames(element, "nopol_examples.nopol_example_2.NopolExample.1.this.limit");
 	}
-	
+
 	@Test
 	public void fieldsOfParameters() {
 		CtElement element = elementInClassToSpoon("nested2 != null");
 		testReachedVariableNames(element, "comparable",
-										  "nested2",
-										  "comparable.privateNestedInstanceField",
-										  "comparable.publicNestedInstanceField",
-										  "comparable.protectedNestedInstanceField",
-										  "spoon.example.ClassToSpoon.protectedStaticField",
-										  "spoon.example.ClassToSpoon.privateStaticField",
-										  "spoon.example.ClassToSpoon.publicStaticField",
-										  "nested2.privateInstanceField",
-										  "nested2.publicInstanceField",
-										  "nested2.protectedInstanceField",
-										  "spoon.example.ClassToSpoon.this.publicInstanceField",
-										  "spoon.example.ClassToSpoon.this.privateInstanceField",
-										  "spoon.example.ClassToSpoon.this.protectedInstanceField");
+				"nested2",
+				"comparable.privateNestedInstanceField",
+				"comparable.publicNestedInstanceField",
+				"comparable.protectedNestedInstanceField",
+				"spoon.example.ClassToSpoon.protectedStaticField",
+				"spoon.example.ClassToSpoon.privateStaticField",
+				"spoon.example.ClassToSpoon.publicStaticField",
+				"nested2.privateInstanceField",
+				"nested2.publicInstanceField",
+				"nested2.protectedInstanceField",
+				"spoon.example.ClassToSpoon.this.publicInstanceField",
+				"spoon.example.ClassToSpoon.this.privateInstanceField",
+				"spoon.example.ClassToSpoon.this.protectedInstanceField");
 	}
-	
+
 	@Test
 	public void fieldsOfParametersFromNestedClass() {
 		CtElement element = elementInClassToSpoon("nested != null");
 		testReachedVariableNames(element, "comparable",
-										  "nested",
-										  "comparable.privateNestedInstanceField",
-										  "comparable.publicNestedInstanceField",
-										  "comparable.protectedNestedInstanceField",
-										  "spoon.example.ClassToSpoon.protectedStaticField",
-										  "spoon.example.ClassToSpoon.privateStaticField",
-										  "spoon.example.ClassToSpoon.publicStaticField",
-										  "nested.publicInstanceField",
-										  "nested.protectedInstanceField",
-										  "nested.privateInstanceField",
-										  "spoon.example.ClassToSpoon.NestedClassToSpoon.this.protectedNestedInstanceField",
-										  "spoon.example.ClassToSpoon.NestedClassToSpoon.this.publicNestedInstanceField",
-										  "spoon.example.ClassToSpoon.NestedClassToSpoon.this.privateNestedInstanceField",
-										  "spoon.example.ClassToSpoon.this.publicInstanceField",
-										  "spoon.example.ClassToSpoon.this.privateInstanceField",
-										  "spoon.example.ClassToSpoon.this.protectedInstanceField");
+				"nested",
+				"comparable.privateNestedInstanceField",
+				"comparable.publicNestedInstanceField",
+				"comparable.protectedNestedInstanceField",
+				"spoon.example.ClassToSpoon.protectedStaticField",
+				"spoon.example.ClassToSpoon.privateStaticField",
+				"spoon.example.ClassToSpoon.publicStaticField",
+				"nested.publicInstanceField",
+				"nested.protectedInstanceField",
+				"nested.privateInstanceField",
+				"spoon.example.ClassToSpoon.NestedClassToSpoon.this.protectedNestedInstanceField",
+				"spoon.example.ClassToSpoon.NestedClassToSpoon.this.publicNestedInstanceField",
+				"spoon.example.ClassToSpoon.NestedClassToSpoon.this.privateNestedInstanceField",
+				"spoon.example.ClassToSpoon.this.publicInstanceField",
+				"spoon.example.ClassToSpoon.this.privateInstanceField",
+				"spoon.example.ClassToSpoon.this.protectedInstanceField");
 	}
-	
+
 	@Test
 	@Ignore
 	public void fieldsOfParametersFromAnonymousClass() {
 		CtElement element = elementInClassToSpoon("comparable != null");
 		testReachedVariableNames(element, "comparable",
-										  "spoon.example.ClassToSpoon.1.this.anonymousField",
-										  "comparable.privateNestedInstanceField",
-										  "comparable.protectedNestedInstanceField",
-										  "comparable.publicNestedInstanceField");
+				"spoon.example.ClassToSpoon.1.this.anonymousField",
+				"comparable.privateNestedInstanceField",
+				"comparable.protectedNestedInstanceField",
+				"comparable.publicNestedInstanceField");
 	}
-	
+
 	@Test
 	public void gettersOfFields() {
 		CtElement element = elementInInfinitelProject(5, "canKeepConsuming(index, word)");
@@ -337,33 +365,33 @@ public class ValuesCollectorTest {
 		expectedGetters.addAll(field, asList("getSize", "getConsumed"));
 		testReachedVariableNames(element, expectedNames, expectedGetters);
 	}
-	
+
 	@Test
 	public void replaceQuotationMarksToCollectSubconditions() {
 		RuntimeValues<Boolean> runtimeValues = RuntimeValues.newInstance();
 		String invocation = runtimeValues.invocationOnCollectionOf("\"aaaa\".startsWith(\"b\")");
-		String toMatch = "try{"+runtimeValues.globallyAccessibleName()+".collectInput(\"\\\"aaaa\\\".startsWith(\\\"b\\\")\",\"aaaa\".startsWith(\"b\"));} catch (Exception ex1) {ex1.printStackTrace();}";
+		String toMatch = "try{" + runtimeValues.globallyAccessibleName() + ".collectInput(\"\\\"aaaa\\\".startsWith(\\\"b\\\")\",\"aaaa\".startsWith(\"b\"));} catch (Exception ex1) {ex1.printStackTrace();}";
 		assertTrue(invocation + " ends with " + toMatch, invocation.endsWith(toMatch));
 	}
-	
-	@SuppressWarnings({ "unchecked", "rawtypes" })
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Test
 	public void collectSubexpressionValues() {
 		CtElement element = elementInNopolProject(8, "((((a * b) < 11) || (productLowerThan100(a, b))) || (!(a < b))) || ((a = -b) > 0)");
 		CtIf ifStatement = (CtIf) testReachedVariableNames(element, "a", "b");
 		List<String> expected = asList("0", "11", "a", "b", "-b",
-									   "(a * b)",
-									   "(a < b)", 
-									   "(!(a < b))", 
-									   "((a * b) < 11)");
+				"(a * b)",
+				"(a < b)",
+				"(!(a < b))",
+				"((a * b) < 11)");
 		checkFoundFromIf(ifStatement, expected, (Multimap) Multimap.newSetMultimap());
 	}
-	
-	@SuppressWarnings({ "unchecked", "rawtypes" })
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
 	private CtStatement testReachedVariableNames(CtElement element, String... expectedNames) {
 		return testReachedVariableNames(element, asList(expectedNames), (Multimap) Multimap.newSetMultimap());
 	}
-	
+
 	private CtStatement testReachedVariableNames(CtElement element, Collection<String> expectedNames, Multimap<String, String> expectedGetters) {
 		assertTrue(CtCodeElement.class.isInstance(element));
 		CtStatement statement = SpoonStatementLibrary.statementOf((CtCodeElement) element);
@@ -371,25 +399,25 @@ public class ValuesCollectorTest {
 		checkFoundInFinder(finder, expectedNames, expectedGetters);
 		return statement;
 	}
-	
+
 	private CtElement elementInNopolProject(int exampleNumber, String codeSnippet) {
 		return elementInClass(NopolTest.absolutePathOf(exampleNumber), codeSnippet);
 	}
-	
+
 	private CtElement elementInInfinitelProject(int exampleNumber, String codeSnippet) {
 		return elementInClass(LoopStatisticsTest.absolutePathOf(exampleNumber), codeSnippet);
 	}
-	
+
 	private CtElement elementInClassToSpoon(String codeSnippet) {
 		String sourcePath = "src/test/resources/spoon/example/ClassToSpoon.java";
 		return elementInClass(sourcePath, codeSnippet);
 	}
-	
+
 	private CtElement elementInClass(String sourcePath, String codeSnippet) {
 		File file = FileLibrary.fileFrom(sourcePath);
 		return elementFromSnippet(file, codeSnippet);
 	}
-	
+
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	private CtElement elementFromSnippet(File sourceFile, String codeSnippet) {
 		Factory model = SpoonModelLibrary.modelFor(new File[]{sourceFile});
@@ -398,12 +426,12 @@ public class ValuesCollectorTest {
 		assertEquals(1, elements.size());
 		return elements.get(0);
 	}
-	
+
 	private void checkFoundFromIf(CtIf ifStatement, Collection<String> expectedNames, Multimap<String, String> expectedGetters) {
 		CollectableValueFinder finder = CollectableValueFinder.valueFinderFromIf(ifStatement);
 		checkFoundInFinder(finder, expectedNames, expectedGetters);
 	}
-	
+
 	private void checkFoundInFinder(CollectableValueFinder finder, Collection<String> expectedNames, Multimap<String, String> expectedGetters) {
 		Collection<String> variables = finder.reachableVariables();
 		System.out.println("Collected variables " + variables);

--- a/nopol/src/test/java/fr/inria/lille/commons/trace/ValuesCollectorTest.java
+++ b/nopol/src/test/java/fr/inria/lille/commons/trace/ValuesCollectorTest.java
@@ -1,20 +1,14 @@
 package fr.inria.lille.commons.trace;
 
-import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
+import fr.inria.lille.commons.spoon.collectable.CollectableValueFinder;
+import fr.inria.lille.commons.spoon.filter.CodeSnippetFilter;
+import fr.inria.lille.commons.spoon.util.SpoonElementLibrary;
+import fr.inria.lille.commons.spoon.util.SpoonModelLibrary;
+import fr.inria.lille.commons.spoon.util.SpoonStatementLibrary;
 import fr.inria.lille.repair.infinitel.loop.implant.LoopStatisticsTest;
+import fr.inria.lille.repair.nopol.NopolTest;
 import org.junit.Ignore;
 import org.junit.Test;
-
 import spoon.reflect.code.CtCodeElement;
 import spoon.reflect.code.CtIf;
 import spoon.reflect.code.CtStatement;
@@ -25,12 +19,15 @@ import xxl.java.container.classic.MetaMap;
 import xxl.java.container.map.Multimap;
 import xxl.java.junit.TestCase;
 import xxl.java.library.FileLibrary;
-import fr.inria.lille.commons.spoon.collectable.CollectableValueFinder;
-import fr.inria.lille.commons.spoon.filter.CodeSnippetFilter;
-import fr.inria.lille.commons.spoon.util.SpoonElementLibrary;
-import fr.inria.lille.commons.spoon.util.SpoonModelLibrary;
-import fr.inria.lille.commons.spoon.util.SpoonStatementLibrary;
-import fr.inria.lille.repair.nopol.NopolTest;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.*;
 
 public class ValuesCollectorTest {
 
@@ -132,6 +129,9 @@ public class ValuesCollectorTest {
 	@SuppressWarnings({"unchecked", "rawtypes"})
 	@Test
 	public void inconsistentSpecificationsAreDiscarded() {
+
+		/* test the consistency management of specification */
+
 		TestCase testA = TestCase.from("com.example", "testA", 1);
 		TestCase testB = TestCase.from("com.example", "testB", 2);
 		TestCase testC = TestCase.from("com.example", "testC", 3);
@@ -171,9 +171,9 @@ public class ValuesCollectorTest {
 		listener.processSuccessfulRun(testB);
 		specifications = listener.specifications();
 		assertEquals(1, specifications.size());
-		assertTrue(specifications.contains(consistent));
+//		assertTrue(specifications.contains(consistent));
 		inconsistencies = listener.inconsistentInputs();
-		assertEquals(1, inconsistencies.size());
+		assertEquals(2, inconsistencies.size());
 		assertTrue(inconsistencies.containsAll(asList(inconsistent.inputs())));
 		
 		listener.processTestStarted(testC);
@@ -186,9 +186,9 @@ public class ValuesCollectorTest {
 		listener.processAfterRun();
 		specifications = listener.specifications();
 		assertEquals(1, specifications.size());
-		assertTrue(specifications.contains(consistent));
+		//assertTrue(specifications.contains(consistent));
 		inconsistencies = listener.inconsistentInputs();
-		assertEquals(1, inconsistencies.size());
+		assertEquals(2, inconsistencies.size());
 		assertTrue(inconsistencies.containsAll(asList(inconsistent.inputs())));
 	}
 	


### PR DESCRIPTION
Improvement of the consistency specifications management. We identify 3 cases:

> case 1: inconsistent specs (same keys, different outcomes): if condition can be flipped, it has no impact, so discarded
> case 2: different input, same output: malformed problems, only the first key set kept.
> case 3: same inputs and same output: redundant tests, discarded.

For each case, a log has been added.

More over, with the fix of consistency, NoPol is able to find a patch for median_90a14c1a from IntroClassJava while it could not before.
