### PR TITLE
chore: change travis to run also on OSX 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
-
+os:
+  - linux
+  - osx
+  
 sudo: true
 
 install: "./.travis_install.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 os:
   - linux
   - osx
-  
+
 sudo: true
 
 install: "./.travis_install.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
 language: java
-os:
-  - linux
-  - osx
+
+matrix:
+  include:
+    - os: osx
+    - os: linux
+      jdk: oraclejdk7
+    - os: linux
+      jdk: oraclejdk8
 
 sudo: true
 
 install: "./.travis_install.sh"
 script: "./.travis_run_tests.sh"
-
-jdk:
-  - oraclejdk7
-  - oraclejdk8
 
 cache:
   directories:

--- a/nopol/src/test/java/fr/inria/lille/commons/synthesis/CodeSynthesisTest.java
+++ b/nopol/src/test/java/fr/inria/lille/commons/synthesis/CodeSynthesisTest.java
@@ -115,7 +115,7 @@ public class CodeSynthesisTest {
 		Specification secondSpecification = new Specification<>(secondValues, true);
 		CodeGenesis genesis = synthesiser.codesSynthesisedFrom(Boolean.class, (List) asList(firstSpecification, secondSpecification));
 		assertTrue(genesis.isSuccessful());
-		assertTrue(genesis.returnStatement() + " is not a valid patch", Arrays.asList("0 == ((cond)?(size):(0))", "1 == ((cond)?(size):(1))").contains(genesis.returnStatement()));
+		assertTrue(genesis.returnStatement() + " is not a valid patch", Arrays.asList("0 == ((cond)?(size):(0))", "1 == ((cond)?(size):(1))","((cond)?(1):(size)) == size").contains(genesis.returnStatement()));
 	}
 
 	@Test
@@ -132,7 +132,7 @@ public class CodeSynthesisTest {
 		Specification fourthS = new Specification<Boolean>(fourth, false);
 		CodeGenesis genesis = synthesiser.codesSynthesisedFrom(Boolean.class, (List) asList(firstS, secondS, thirdS, fourthS));
 		assertTrue(genesis.isSuccessful());
-		assertTrue(asList("(q + p) == n", "p == (n) - (q)", "q + p <= n").contains(genesis.returnStatement()));
+		assertTrue(asList("(q + p) == n", "p == (n) - (q)", "q + p <= n","(n) - (q) == p").contains(genesis.returnStatement()));
 	}
 
 	@Test

--- a/nopol/src/test/java/fr/inria/lille/repair/nopol/NopolTest.java
+++ b/nopol/src/test/java/fr/inria/lille/repair/nopol/NopolTest.java
@@ -84,7 +84,7 @@ public class NopolTest {
 		List<Patch> patches = TestUtility.setupAndRun(executionType, 5, config, listener);
 
 		TestUtility.assertPatches(20, expectedFailedTests, expectedStatementType, listener, patches);
-		TestUtility.assertAgainstKnownPatches(patches.get(0), "-1 <= a", "1 <= a", "(r)<=(a)", "(-1)<(a)", "(0)<=(a)", "0 <= a");
+		TestUtility.assertAgainstKnownPatches(patches.get(0), "-1 <= a", "-1 < a", "1 <= a", "(r)<=(a)", "(-1)<(a)", "(0)<=(a)", "0 <= a");
 	}
 
 	@Test
@@ -128,7 +128,8 @@ public class NopolTest {
 				"((intermediaire == 0) && (!(a < 3))) || (intermediaire == a)",
 				"((intermediaire) - (a) + 1 < -1) && (intermediaire == 0)",
 				"!((-1 <= (1) - (a + intermediaire)) || ((0) != (intermediaire)))",
-				"(1 < a + -1) && ((a + -1 <= -1) || (intermediaire == 0))");
+				"(1 < a + -1) && ((a + -1 <= -1) || (intermediaire == 0))",
+				"(2 < a) && (intermediaire == 0)");
 	}
 
 	@Test
@@ -180,6 +181,6 @@ public class NopolTest {
 		List<Patch> patches = TestUtility.setupAndRun(executionType, 5, config, listener);
 
 		TestUtility.assertPatches(20, expectedFailedTests, expectedStatementType, listener, patches);
-		TestUtility.assertAgainstKnownPatches(patches.get(0),  "-1 <= a", "1 <= a", "(r)<=(a)", "(-1)<(a)", "(0)<=(a)", "0 <= a");
+		TestUtility.assertAgainstKnownPatches(patches.get(0),  "-1 <= a", "1 <= a", "(r)<=(a)", "(-1)<(a)", "(0)<=(a)", "0 <= a", "-1 < a");
 	}
 }

--- a/nopol/src/test/java/fr/inria/lille/spirals/evo/TestPatchEvo.java
+++ b/nopol/src/test/java/fr/inria/lille/spirals/evo/TestPatchEvo.java
@@ -58,7 +58,8 @@ public class TestPatchEvo {
 		assertFalse(Main.patches.get("test_evo_example_generated_0").isEmpty());
 
 		//check if we got the rights patches
-		assertEquals("evo_examples.evo_example_1.EvoExample:9: CONDITIONAL number < evo_examples.evo_example_1.EvoExample.this.value", Main.patches.get("basic").get(0).toString());
+		//assertEquals("evo_examples.evo_example_1.EvoExample:9: CONDITIONAL number < evo_examples.evo_example_1.EvoExample.this.value", Main.patches.get("basic").get(0).toString());
+		fixComparison(Main.patches.get("basic").get(0), "number < evo_examples.evo_example_1.EvoExample.this.value", "number < 1");
 		fixComparison(Main.patches.get("test_evo_example_generated_0").get(0), "number < 1", "number <= 0" );
 		assertEquals(0, Main.patches.get("test_evo_example_generated_1").size());
 		assertEquals(1, Main.keptMethods.size());


### PR DESCRIPTION
As the Z3 solver is not exactly the same on linux and OSX, and Nopol does not generate exactly the same patches depending on the system, I made slight changes to pass tests on OS X and to run Travis using OSX.