### PR TITLE
Change the code of the CustomClassLoaderThreadFactory

### DIFF
--- a/nopol/src/main/java/xxl/java/junit/CustomClassLoaderThreadFactory.java
+++ b/nopol/src/main/java/xxl/java/junit/CustomClassLoaderThreadFactory.java
@@ -1,5 +1,6 @@
 package xxl.java.junit;
 
+import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 
 public final class CustomClassLoaderThreadFactory implements ThreadFactory {
@@ -10,8 +11,7 @@ public final class CustomClassLoaderThreadFactory implements ThreadFactory {
 
     @Override
     public Thread newThread(Runnable r) {
-        Thread newThread = new Thread(r);
-        newThread.setDaemon(true);
+        Thread newThread = Executors.defaultThreadFactory().newThread(r);
         newThread.setContextClassLoader(customClassLoader());
         return newThread;
     }


### PR DESCRIPTION
Use the default threadFactory to prepare the threads. Remove the setDaemon to avoid keeping threads after the execution is terminate see https://docs.oracle.com/javase/7/docs/api/java/lang/Thread.html#setDaemon(boolean): 

> The Java Virtual Machine exits when the only threads running are all daemon threads. 