### PR TITLE
Refactor Config to extract getLocalizer and to keep a simple constructor

### DIFF
--- a/nopol/src/main/java/fr/inria/lille/repair/common/config/Config.java
+++ b/nopol/src/main/java/fr/inria/lille/repair/common/config/Config.java
@@ -50,7 +50,6 @@ public class Config implements Serializable {
 	}
 
 	private final String filename = "config.ini";
-	private Properties p;
 
 	private int synthesisDepth;
 	private boolean collectStaticMethods;
@@ -100,7 +99,7 @@ public class Config implements Serializable {
 	}
 
 	private void initFromFile() {
-		p = new Properties();
+		Properties p = new Properties();
 		try {
 			ClassLoader classLoader = getClass().getClassLoader();
 			p.load(classLoader.getResourceAsStream(filename));

--- a/nopol/src/main/java/fr/inria/lille/repair/common/config/Config.java
+++ b/nopol/src/main/java/fr/inria/lille/repair/common/config/Config.java
@@ -50,7 +50,7 @@ public class Config implements Serializable {
 	}
 
 	private final String filename = "config.ini";
-	private final Properties p;
+	private Properties p;
 
 	private int synthesisDepth;
 	private boolean collectStaticMethods;
@@ -96,6 +96,10 @@ public class Config implements Serializable {
 	private int complianceLevel;
 
 	public Config() {
+		this.initFromFile();
+	}
+
+	private void initFromFile() {
 		p = new Properties();
 		try {
 			ClassLoader classLoader = getClass().getClassLoader();
@@ -133,20 +137,6 @@ public class Config implements Serializable {
 		} catch (IOException e) {
 			throw new RuntimeException("Unable to load config file", e);
 		}
-	}
-
-	public URL[] buildClasspath() {
-		return JavaLibrary.classpathFrom(this.getProjectClasspath());
-	}
-
-	public File[] buildSourceFiles() {
-		File[] sourceFiles = new File[this.getProjectSourcePath().length];
-		for (int i = 0; i < this.getProjectSourcePath().length; i++) {
-			String path = this.getProjectSourcePath()[i];
-			File sourceFile = FileLibrary.openFrom(path);
-			sourceFiles[i] = sourceFile;
-		}
-		return sourceFiles;
 	}
 
 	public long getMaxTimeEachTypeOfFixInMinutes() {
@@ -446,20 +436,8 @@ public class Config implements Serializable {
 		this.maxTimeBuildPatch = maxTimeBuildPatch;
 	}
 
-	public FaultLocalizer getLocalizer(File[] sourceFiles, URL[] classpath, String[] testClasses) {
-		switch (this.localizer) {
-			case GZOLTAR:
-				try {
-					return new GZoltarFaultLocalizer(classpath, testClasses);
-				} catch (IOException e) {
-					throw new RuntimeException(e);
-				}
-			case DUMB:
-				return new DumbFaultLocalizerImpl(sourceFiles, classpath, testClasses, this);
-			case OCHIAI:
-			default:
-				return new OchiaiFaultLocalizer(sourceFiles, classpath, testClasses, this);
-		}
+	public NopolLocalizer getLocalizer() {
+		return localizer;
 	}
 
 	public void setLocalizer(NopolLocalizer localizer) {


### PR DESCRIPTION
Config should be a very simple class constituted with getter/setters and should not do smart things. I extracted getLocalizer to put it in Nopol and create a private method for the constructor content in case we want to create a specific factory to create Config from file. 