### PR TITLE
Add the capability to bypass regression step

### DIFF
--- a/nopol/src/main/java/fr/inria/lille/repair/common/config/NopolContext.java
+++ b/nopol/src/main/java/fr/inria/lille/repair/common/config/NopolContext.java
@@ -17,7 +17,6 @@ import java.util.Properties;
 public class NopolContext implements Serializable {
 
 	private static final long serialVersionUID = -2542128741040978263L;
-	private boolean json;
 
 	public enum NopolMode {
 		REPAIR,
@@ -47,18 +46,25 @@ public class NopolContext implements Serializable {
 
 	private final String filename = "config.ini";
 
-	private int synthesisDepth;
+
 	private boolean collectStaticMethods;
 	private boolean collectStaticFields;
 	private boolean collectLiterals;
 	private boolean collectOnlyUsedMethod;
 	private boolean onlyOneSynthesisResult;
 	private boolean sortExpressions;
+	private boolean skipRegressionStep; // this option allow to skip regression step: it could create a patch which broke another test.
+	private boolean json;
+
 	private int maxLineInvocationPerTest;
 	private int timeoutMethodInvocation;
+	private int synthesisDepth;
+	private int complianceLevel;
 	private int maxTimeInMinutes = 10;
 	private int dataCollectionTimeoutInSecondForSynthesis = 15*60;
+
 	private String outputFolder;
+	private String solverPath;
 
 	private double addWeight;
 	private double subWeight;
@@ -74,6 +80,7 @@ public class NopolContext implements Serializable {
 	private double fieldAccessWeight;
 	private double constantWeight;
 	private double variableWeight;
+
 	private long timeoutTestExecution;
 	private long maxTimeBuildPatch;
 	private long maxTimeEachTypeOfFixInMinutes;
@@ -84,13 +91,12 @@ public class NopolContext implements Serializable {
 	private NopolOracle oracle = NopolOracle.ANGELIC;
 	private NopolSolver solver = NopolSolver.Z3;
 	private NopolLocalizer localizer = NopolLocalizer.OCHIAI;
-	private String solverPath;
+
 
 	private File[] projectSources;
 	private URL[] projectClasspath;
 	private String[] projectTests;
 
-	private int complianceLevel;
 
 	public NopolContext() {
 		this.initFromFile();
@@ -483,6 +489,14 @@ public class NopolContext implements Serializable {
 
 	public void setDataCollectionTimeoutInSecondForSynthesis(int dataCollectionTimeoutInSecondForSynthesis) {
 		this.dataCollectionTimeoutInSecondForSynthesis = dataCollectionTimeoutInSecondForSynthesis;
+	}
+
+	public boolean isSkipRegressionStep() {
+		return skipRegressionStep;
+	}
+
+	public void setSkipRegressionStep(boolean skipRegressionStep) {
+		this.skipRegressionStep = skipRegressionStep;
 	}
 
 	@Override

--- a/nopol/src/main/java/fr/inria/lille/repair/nopol/NoPol.java
+++ b/nopol/src/main/java/fr/inria/lille/repair/nopol/NoPol.java
@@ -244,7 +244,7 @@ public class NoPol {
 		List<Patch> tmpPatches = synth.buildPatch(classpath, tests, failingTest, nopolContext.getMaxTimeBuildPatch());
 		for (int i = 0; i < tmpPatches.size(); i++) {
 			Patch patch = tmpPatches.get(i);
-			if (isOk(patch, tests, synth.getProcessor())) {
+			if (nopolContext.isSkipRegressionStep() || isOk(patch, tests, synth.getProcessor())) {
 				patches.add(patch);
 				if (nopolContext.isOnlyOneSynthesisResult()) {
 					return patches;

--- a/nopol/src/test/java/fr/inria/lille/repair/nopol/NopolTest.java
+++ b/nopol/src/test/java/fr/inria/lille/repair/nopol/NopolTest.java
@@ -1,16 +1,21 @@
 package fr.inria.lille.repair.nopol;
 
+import fr.inria.lille.commons.synthesis.smt.solver.SolverFactory;
 import fr.inria.lille.repair.TestUtility;
+import fr.inria.lille.repair.common.config.NopolContext;
 import fr.inria.lille.repair.common.patch.Patch;
 import fr.inria.lille.repair.common.synth.StatementType;
 import org.junit.Ignore;
 import org.junit.Test;
 import xxl.java.junit.TestCasesListener;
+import xxl.java.junit.TestSuiteExecution;
 
+import java.net.URLClassLoader;
 import java.util.Collection;
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import static org.junit.Assert.assertTrue;
 
 public class NopolTest {
 
@@ -205,5 +210,17 @@ public class NopolTest {
 
 		TestUtility.assertPatches(20, expectedFailedTests, expectedStatementType, listener, patches);
 		TestUtility.assertAgainstKnownPatches(patches.get(0),  "-1 <= a", "1 <= a", "(r)<=(a)", "(-1)<(a)", "(0)<=(a)", "0 <= a", "-1 < a");
+	}
+
+	@Test
+	public void testSkippingRegressionStepLeadToAPatch() {
+		NopolContext nopolContext = TestUtility.configForExample(executionType, 1);
+		nopolContext.setType(StatementType.CONDITIONAL);
+		nopolContext.setSkipRegressionStep(true);
+		SolverFactory.setSolver("z3", TestUtility.solverPath);
+		URLClassLoader classLoader = new URLClassLoader(nopolContext.getProjectClasspath());
+		TestSuiteExecution.runCasesIn(nopolContext.getProjectTests(), classLoader, new TestCasesListener(), nopolContext);
+		List<Patch> patches = TestUtility.patchFor(executionType, nopolContext);
+		assertTrue(patches.size() > 0);
 	}
 }


### PR DESCRIPTION
In that case, tests are not running after a patch is found.

Fix #88 on test class. 