### PR TITLE
Set thread as a daemon is the thread factory

### DIFF
--- a/nopol/src/main/java/xxl/java/junit/CustomClassLoaderThreadFactory.java
+++ b/nopol/src/main/java/xxl/java/junit/CustomClassLoaderThreadFactory.java
@@ -12,6 +12,7 @@ public final class CustomClassLoaderThreadFactory implements ThreadFactory {
     @Override
     public Thread newThread(Runnable r) {
         Thread newThread = Executors.defaultThreadFactory().newThread(r);
+        newThread.setDaemon(true); // use to avoid a main process to continue running waiting for this thread end at the end of execution
         newThread.setContextClassLoader(customClassLoader());
         return newThread;
     }


### PR DESCRIPTION
As explained in http://stackoverflow.com/a/16426452/750142 if threads are launched as non-daemon, the main thread will wait their end before terminating. And as explained in https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/Executors.html#defaultThreadFactory() the defaultThreadFactory create threads as non-daemon threads. 