### PR TITLE
fix: removed the hard code config where are inconsistence with config…

### DIFF
--- a/nopol/src/main/java/fr/inria/lille/repair/Main.java
+++ b/nopol/src/main/java/fr/inria/lille/repair/Main.java
@@ -167,8 +167,9 @@ public class Main {
 			nopolContext.setSolverPath(jsapConfig.getString("solverPath"));
 			SolverFactory.setSolver(nopolContext.getSolver(), nopolContext.getSolverPath());
 		}
-		nopolContext.setComplianceLevel(jsapConfig.getInt("complianceLevel", 7)); nopolContext.setMaxTimeInMinutes(jsapConfig.getInt("maxTime", nopolContext.getMaxTimeInMinutes()));
-		nopolContext.setMaxTimeEachTypeOfFixInMinutes(jsapConfig.getInt("maxTimeType",5));
+		nopolContext.setComplianceLevel(jsapConfig.getInt("complianceLevel", nopolContext.getComplianceLevel())); 
+		nopolContext.setMaxTimeInMinutes(jsapConfig.getInt("maxTime", nopolContext.getMaxTimeInMinutes()));
+		nopolContext.setMaxTimeEachTypeOfFixInMinutes(jsapConfig.getLong("maxTimeType",nopolContext.getMaxTimeEachTypeOfFixInMinutes()));
 
 		nopolContext.setLocalizer(strToLocalizer(jsapConfig.getString("faultLocalization")));
 		nopolContext.setOutputFolder(jsapConfig.getString("outputFolder"));

--- a/nopol/src/main/java/fr/inria/lille/repair/common/config/NopolContext.java
+++ b/nopol/src/main/java/fr/inria/lille/repair/common/config/NopolContext.java
@@ -62,7 +62,7 @@ public class NopolContext implements Serializable {
 	private int timeoutMethodInvocation;
 	private int synthesisDepth;
 	private int complianceLevel;
-	private int maxTimeInMinutes = 10;
+	private int maxTimeInMinutes;
 	private int dataCollectionTimeoutInSecondForSynthesis = 15*60;
 
 	private String outputFolder;
@@ -161,6 +161,7 @@ public class NopolContext implements Serializable {
 			maxTimeBuildPatch = Long.parseLong(p.getProperty("maxTimeBuildPatch", "15L"));
 			maxTimeEachTypeOfFixInMinutes = Long.parseLong(p.getProperty("maxTimeEachTypeOfFixInMinutes", "5"));
 			complianceLevel = Integer.parseInt(p.getProperty("complianceLevel", "7"));
+			maxTimeInMinutes = Integer.parseInt(p.getProperty("maxTimeInMinutes", "10"));
 		} catch (IOException e) {
 			throw new RuntimeException("Unable to load config file", e);
 		}

--- a/nopol/src/main/resources/default-nopol-config.ini
+++ b/nopol/src/main/resources/default-nopol-config.ini
@@ -1,6 +1,7 @@
 [general]
 complianceLevel=7
 timeoutTestExecution=120
+maxTimeInMinutes=10
 
 [synth]
 depth=3

--- a/nopol/src/main/resources/default-nopol-config.ini
+++ b/nopol/src/main/resources/default-nopol-config.ini
@@ -1,7 +1,11 @@
 [general]
 complianceLevel=7
+
+# max time for a singe test method execution
 timeoutTestExecution=120
-maxTimeInMinutes=10
+
+# max time for the entire repair process
+maxTimeInMinutes=60
 
 [synth]
 depth=3


### PR DESCRIPTION
Hi,
When I am using Nopol to do my automatic repair experiment, I found the config is very confusing. For example,  the value of MaxTimeEachTypeOfFixInMinutes in Nopol context is either read from command line or hard-coded as 5 mins even thought I modified the value of this property  in config file.  Also the MaxTimeInMinutes for the entire repair process. 

I am proposing this PR to read the default value from config file instead of hard coding value. 