### PR TITLE
add tests and change timeout behavior

### DIFF
--- a/nopol/src/test/java/fr/inria/lille/commons/trace/NonDeterministicSpecificationTest.java
+++ b/nopol/src/test/java/fr/inria/lille/commons/trace/NonDeterministicSpecificationTest.java
@@ -1,0 +1,89 @@
+package fr.inria.lille.commons.trace;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+import fr.inria.lille.repair.common.config.NopolContext;
+import fr.inria.lille.repair.common.config.NopolContext.NopolLocalizer;
+import fr.inria.lille.repair.nopol.NoPol;
+import fr.inria.lille.repair.nopol.NopolResult;
+
+/**
+ * 
+ * These tests expose Nopol non-deterministic issues.
+ * 
+ * Test1: find_patch_with_junit_timeout_test: Some tests fail due to Junit
+ * timeout but some succeed. No runtime value collected in failing tests.
+ * 
+ * Test2: find_patch_no_junit_timeout_test We removed Junit timeout. But the
+ * results are still non-determined. Comparing the specifications we collected,
+ * we found out same input value but with different outputs. This could the
+ * reason that result in non-determine results of Nopol.
+ *
+ */
+public class NonDeterministicSpecificationTest {
+
+	/**
+	 * In this test, we run Nopol against find_in_sorted program at most 20 times to
+	 * find patches. Once we have two results that patch found and patch not found,
+	 * the test stop.
+	 */
+
+	@Test
+	public void find_patch_with_junit_timeout_test() throws MalformedURLException {
+		String testClassesName = "nopol_examples.quixbug.FIND_IN_SORTED_TIMEOUT_TEST";
+		Set<Boolean> patchResultSet = new HashSet<Boolean>();
+		for (int i = 0; i < 20; i++) {
+			if (patchResultSet.size() == 2) {
+				break;
+			}
+			Boolean hasPatch = find_in_sorted_program(testClassesName);
+			patchResultSet.add(hasPatch);
+			System.out.println(hasPatch);
+		}
+		assertEquals(2, patchResultSet.size());
+	}
+
+	
+	// Comment out this test because running this test requires long time
+	/*
+	 @Test
+	 public void find_patch_no_junit_timeout_test() throws MalformedURLException {
+	 String testClassesName = "nopol_examples.quixbug.FIND_IN_SORTED_TEST";
+	   Set<Boolean> patchResultSet = new HashSet<Boolean>();
+	 for (int i = 0; i < 20; i++) {
+	 if (patchResultSet.size() == 2) {
+	 break;
+	 }
+	 Boolean hasPatch = find_in_sorted_program(testClassesName);
+	 patchResultSet.add(hasPatch);
+	 System.out.println(hasPatch);
+	 }
+	 assertEquals(2, patchResultSet.size());
+	 }
+	 */
+
+	private boolean find_in_sorted_program(String testClassesName) throws MalformedURLException {
+		File[] sources = new File[] {
+				new File("../test-projects/src/main/java/nopol_examples/quixbug/FIND_IN_SORTED.java") };
+		URL[] classpath = new URL[] { new File("../test-projects/target/classes").toURI().toURL(),
+				new File("../test-projects/target/test-classes").toURI().toURL() };
+		String[] testClasses = new String[] { testClassesName };
+		NopolContext nopolContext = new NopolContext(sources, classpath, testClasses);
+		nopolContext.setLocalizer(NopolLocalizer.COCOSPOON);
+		NoPol nopol = new NoPol(nopolContext);
+		nopol.build();
+		NopolResult result = nopol.getNopolResult();
+		return result.getPatches().size() == 0 ? false : true;
+	}
+
+
+}

--- a/test-projects/src/main/java/nopol_examples/quixbug/FIND_IN_SORTED.java
+++ b/test-projects/src/main/java/nopol_examples/quixbug/FIND_IN_SORTED.java
@@ -1,0 +1,29 @@
+package nopol_examples.quixbug;
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+/**
+ *
+ * @author derricklin
+ */
+public class FIND_IN_SORTED {
+    public static int binsearch(int[] arr, int x, int start, int end) {
+        if (start == end) {
+            return -1;
+        }
+        int mid = start + (end - start) / 2; // check this is floor division
+        if (x < arr[mid]) {
+            return binsearch(arr, x, start, mid);
+        } else if (x > arr[mid]) {
+            return binsearch(arr, x, mid, end);
+        } else {
+            return mid;
+        }
+    }
+
+    public static int find_in_sorted(int[] arr, int x) {
+        return binsearch(arr, x, 0, arr.length);
+    }
+}

--- a/test-projects/src/test/java/nopol_examples/quixbug/FIND_IN_SORTED_TEST.java
+++ b/test-projects/src/test/java/nopol_examples/quixbug/FIND_IN_SORTED_TEST.java
@@ -1,0 +1,49 @@
+package nopol_examples.quixbug;
+
+import nopol_examples.quixbug.FIND_IN_SORTED;
+
+public class FIND_IN_SORTED_TEST {
+    @org.junit.Test()
+    public void test_0() throws java.lang.Exception {
+        int result = FIND_IN_SORTED.find_in_sorted(new int[]{3,4,5,5,5,5,6},(int)5);
+        org.junit.Assert.assertEquals( (int) 3, result);
+    }
+
+    @org.junit.Test()
+    public void test_1() throws java.lang.Exception {
+        int result = FIND_IN_SORTED.find_in_sorted(new int[]{1,2,3,4,6,7,8},(int)5);
+        org.junit.Assert.assertEquals( (int) -1, result);
+    }
+
+    @org.junit.Test()
+    public void test_2() throws java.lang.Exception {
+        int result = FIND_IN_SORTED.find_in_sorted(new int[]{1,2,3,4,6,7,8},(int)4);
+        org.junit.Assert.assertEquals( (int) 3, result);
+    }
+
+    @org.junit.Test()
+    public void test_3() throws java.lang.Exception {
+        int result = FIND_IN_SORTED.find_in_sorted(new int[]{2,4,6,8,10,12,14,16,18,20},(int)18);
+        org.junit.Assert.assertEquals( (int) 8, result);
+    }
+
+    @org.junit.Test()
+    public void test_4() throws java.lang.Exception {
+        int result = FIND_IN_SORTED.find_in_sorted(new int[]{3,5,6,7,8,9,12,13,14,24,26,27},(int)0);
+        org.junit.Assert.assertEquals( (int) -1, result);
+    }
+
+    @org.junit.Test()
+    public void test_5() throws java.lang.Exception {
+        int result = FIND_IN_SORTED.find_in_sorted(new int[]{3,5,6,7,8,9,12,12,14,24,26,27},(int)12);
+        org.junit.Assert.assertEquals( (int) 6, result);
+    }
+    
+    @org.junit.Test()
+    public void test_6() throws java.lang.Exception {
+        int result = FIND_IN_SORTED.find_in_sorted(new int[]{24,26,28,50,59},(int)101);
+        org.junit.Assert.assertEquals( (int) -1, result);
+    }
+
+}
+

--- a/test-projects/src/test/java/nopol_examples/quixbug/FIND_IN_SORTED_TIMEOUT_TEST.java
+++ b/test-projects/src/test/java/nopol_examples/quixbug/FIND_IN_SORTED_TIMEOUT_TEST.java
@@ -1,0 +1,49 @@
+package nopol_examples.quixbug;
+
+import nopol_examples.quixbug.FIND_IN_SORTED;
+
+public class FIND_IN_SORTED_TIMEOUT_TEST {
+    @org.junit.Test(timeout = 4000)
+    public void test_0() throws java.lang.Exception {
+        int result = FIND_IN_SORTED.find_in_sorted(new int[]{3,4,5,5,5,5,6},(int)5);
+        org.junit.Assert.assertEquals( (int) 3, result);
+    }
+
+    @org.junit.Test(timeout = 4000)
+    public void test_1() throws java.lang.Exception {
+        int result = FIND_IN_SORTED.find_in_sorted(new int[]{1,2,3,4,6,7,8},(int)5);
+        org.junit.Assert.assertEquals( (int) -1, result);
+    }
+
+    @org.junit.Test(timeout = 4000)
+    public void test_2() throws java.lang.Exception {
+        int result = FIND_IN_SORTED.find_in_sorted(new int[]{1,2,3,4,6,7,8},(int)4);
+        org.junit.Assert.assertEquals( (int) 3, result);
+    }
+
+    @org.junit.Test(timeout = 4000)
+    public void test_3() throws java.lang.Exception {
+        int result = FIND_IN_SORTED.find_in_sorted(new int[]{2,4,6,8,10,12,14,16,18,20},(int)18);
+        org.junit.Assert.assertEquals( (int) 8, result);
+    }
+
+    @org.junit.Test(timeout = 4000)
+    public void test_4() throws java.lang.Exception {
+        int result = FIND_IN_SORTED.find_in_sorted(new int[]{3,5,6,7,8,9,12,13,14,24,26,27},(int)0);
+        org.junit.Assert.assertEquals( (int) -1, result);
+    }
+
+    @org.junit.Test(timeout = 4000)
+    public void test_5() throws java.lang.Exception {
+        int result = FIND_IN_SORTED.find_in_sorted(new int[]{3,5,6,7,8,9,12,12,14,24,26,27},(int)12);
+        org.junit.Assert.assertEquals( (int) 6, result);
+    }
+    
+    @org.junit.Test(timeout = 4000)
+    public void test_6() throws java.lang.Exception {
+        int result = FIND_IN_SORTED.find_in_sorted(new int[]{24,26,28,50,59},(int)101);
+        org.junit.Assert.assertEquals( (int) -1, result);
+    }
+
+}
+


### PR DESCRIPTION
Hi,

Two test cases added to test non-deterministic Nopol results #146 
Found out 1:
If the Junit tests are setting a timeout, there would be insufficient time for Nopol to execute tests and collect run time values.  In this case, if tests fail due to runtime, no runtime values could be collected. In this case, we should check if there is a Junit timeout and remind the impact to users.

Found out 2:
There is a TestExecutionTimeOut setting to run each test. However, if one test execution time is exceed TestExecutionTimeOut setting, Nopol stops to analyze current suspicious statement (See the exception is caught in method executeNopolProcessor in Nopol class). I was thinking should we just skip this test and continue other tests instead of skip current statement( source location).

Found out 3:
Besides above two possibility that could result in non-deterministic result, for many cases, there is another possible that specifications are non-deterministic. Comparing the patch found and patch not found data, we found that same input value but with different outputs. This is because Nopol discard the second one if there are two different outcomes for the same input value. However, the tests execution sequence is random, which means our specification collection randomly collect one result and discard the contradictory one. Thus our specifications collected are non-deterministic and Nopol result is non-deterministic.



 










