### PR TITLE
Remove implicit dependency towards log4j 1.2.17

### DIFF
--- a/nopol/src/main/java/fr/inria/lille/commons/spoon/SpoonedFile.java
+++ b/nopol/src/main/java/fr/inria/lille/commons/spoon/SpoonedFile.java
@@ -2,7 +2,6 @@ package fr.inria.lille.commons.spoon;
 
 import fr.inria.lille.commons.spoon.util.SpoonModelLibrary;
 import fr.inria.lille.repair.common.config.NopolContext;
-import org.apache.log4j.Level;
 import org.slf4j.Logger;
 import spoon.compiler.Environment;
 import spoon.processing.ProcessInterruption;
@@ -56,7 +55,7 @@ public abstract class SpoonedFile {
         factory = SpoonModelLibrary.newFactory();
         factory.getEnvironment().setComplianceLevel(nopolContext.getComplianceLevel());
         factory.getEnvironment().setCommentEnabled(false);
-        factory.getEnvironment().setLevel(Level.OFF.toString());
+        factory.getEnvironment().setLevel("OFF");
 
         factory = SpoonModelLibrary.modelFor(factory, sourceFiles, projectClasspath());
 

--- a/nopol/src/main/java/fr/inria/lille/commons/spoon/SpoonedFile.java
+++ b/nopol/src/main/java/fr/inria/lille/commons/spoon/SpoonedFile.java
@@ -55,7 +55,7 @@ public abstract class SpoonedFile {
         factory = SpoonModelLibrary.newFactory();
         factory.getEnvironment().setComplianceLevel(nopolContext.getComplianceLevel());
         factory.getEnvironment().setCommentEnabled(false);
-        factory.getEnvironment().setLevel("OFF");
+        factory.getEnvironment().setLevel("OFF"); // no logs
 
         factory = SpoonModelLibrary.modelFor(factory, sourceFiles, projectClasspath());
 


### PR DESCRIPTION
Compilation fails if log4j 1.2.17 is not in the classpath, but it is not declared as a dependency. (It only works because spoon use to declare it.)

See https://ci.inria.fr/sos/job/nopol/719