### PR TITLE
WIP: Removed com.sun.tools from System Scope

### DIFF
--- a/nopol/pom.xml
+++ b/nopol/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>fr.inria.gforge.spirals</groupId>
     <artifactId>nopol</artifactId>
-    <version>0.2-SNAPSHOT</version>
+    <version>0.3-SNAPSHOT</version>
     <name>Nopol</name>
     <description>Java Program Repair via Conditional Expression Replacement</description>
     <inceptionYear>2013</inceptionYear>
@@ -114,13 +114,6 @@
             <groupId>org.smtlib</groupId>
             <artifactId>smtlib</artifactId>
             <version>0.9.7.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun</groupId>
-            <artifactId>tools</artifactId>
-            <version>1.4.2</version>
-            <scope>system</scope>
-            <systemPath>${java.home}/../lib/tools.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>com.gzoltar</groupId>


### PR DESCRIPTION
Hi, 

this is an issue originating from https://github.com/SpoonLabs/astor/issues/243 and similar to #211 .

The build proceeds fine, and when I use the 0.3-Snapshot Astor also builds without issues. 
Astors tests run too, but some of them are failing. 

However I must admit that the tests are failing, but I have no clue which ones are the serious ones. 
Second look would be great @martinezmatias . 

