### PR TITLE
Upgrade guava to 30.1-jre

### DIFF
--- a/nopol/pom.xml
+++ b/nopol/pom.xml
@@ -157,7 +157,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>15.0</version>
+                <version>30.1-jre</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Upgrades guava to latest version to fix a compatibility issue with other dependencies in https://github.com/eclipse/repairnator