### PR TITLE
Report not-enough-specs and no-angelic-value cases separately

### DIFF
--- a/nopol/src/main/java/fr/inria/lille/repair/nopol/synth/SMTNopolSynthesizer.java
+++ b/nopol/src/main/java/fr/inria/lille/repair/nopol/synth/SMTNopolSynthesizer.java
@@ -68,6 +68,14 @@ public final class SMTNopolSynthesizer<T> implements Synthesizer {
 
 		final Collection<Specification<T>> data = instrumentedProgram.collectSpecifications(classpath, testClasses, failures);
 
+		if (data.size() == 0) {
+			LoggerFactory.getLogger(this.getClass()).info("No angelic value for {} ({}).", sourceLocation, type.toString());
+			return Collections.EMPTY_LIST;
+		}
+
+		nopolResult.incrementNbAngelicValues(sourceLocation, conditionalProcessor);
+		nbStatementsWithAngelicValue++;
+
 		// XXX FIXME TODO move this
 		// there should be at least two sets of values, otherwise the patch would be "true" or "false"
 		int dataSize = data.size();
@@ -76,10 +84,6 @@ public final class SMTNopolSynthesizer<T> implements Synthesizer {
 			// we return so that we can start working on the next statement in the suspicious list
 			return Collections.EMPTY_LIST;
 		}
-
-
-		nopolResult.incrementNbAngelicValues(sourceLocation, conditionalProcessor);
-		nbStatementsWithAngelicValue++;
 
 		//collects available constants
 		Map<String, Number> constants = new HashMap<>();

--- a/nopol/src/main/java/fr/inria/lille/repair/nopol/synth/SMTNopolSynthesizer.java
+++ b/nopol/src/main/java/fr/inria/lille/repair/nopol/synth/SMTNopolSynthesizer.java
@@ -68,7 +68,8 @@ public final class SMTNopolSynthesizer<T> implements Synthesizer {
 
 		final Collection<Specification<T>> data = instrumentedProgram.collectSpecifications(classpath, testClasses, failures);
 
-		if (data.size() == 0) {
+		int dataSize = data.size();
+		if (dataSize == 0) {
 			LoggerFactory.getLogger(this.getClass()).info("No angelic value for {} ({}).", sourceLocation, type.toString());
 			return Collections.EMPTY_LIST;
 		}
@@ -78,7 +79,6 @@ public final class SMTNopolSynthesizer<T> implements Synthesizer {
 
 		// XXX FIXME TODO move this
 		// there should be at least two sets of values, otherwise the patch would be "true" or "false"
-		int dataSize = data.size();
 		if (dataSize < 2) {
 			LoggerFactory.getLogger(this.getClass()).info("Not enough specifications: {}. A trivial patch is \"true\" or \"false\", please write new tests specifying {}.", dataSize, sourceLocation);
 			// we return so that we can start working on the next statement in the suspicious list

--- a/nopol/src/test/java/fr/inria/lille/repair/nopol/NopolTest.java
+++ b/nopol/src/test/java/fr/inria/lille/repair/nopol/NopolTest.java
@@ -286,4 +286,16 @@ public class NopolTest {
 		assertEquals(10, nopol.build().getPatches().size());
 	}
 
+	@Test
+	public void testNbAngelicValuesWithNotEnoughSpecifications() {
+		NopolContext nopolContext = TestUtility.configForExample(executionType, 14);
+		nopolContext.setType(RepairType.CONDITIONAL);
+		SolverFactory.setSolver("z3", TestUtility.solverPath);
+
+		NoPol nopol = new NoPol(nopolContext);
+		NopolResult result = nopol.build();
+
+		assertEquals(1, result.getNbAngelicValues());
+		assertEquals(NopolStatus.NO_SYNTHESIS, result.getNopolStatus());
+	}
 }

--- a/test-projects/src/main/java/nopol_examples/nopol_example_14/NopolExample.java
+++ b/test-projects/src/main/java/nopol_examples/nopol_example_14/NopolExample.java
@@ -1,0 +1,16 @@
+package nopol_examples.nopol_example_14;
+
+public class NopolExample {
+
+	/*
+   * Buggy implementation of the identity function.
+	 */
+	public int identity(int a){
+		if (a == 1) { // With *only* the test a = 1, there are "Not enough specifications",
+									// yet this statement admits an angelic value. 
+			return 0;
+		}
+
+		return a;
+	}
+}

--- a/test-projects/src/test/java/nopol_examples/nopol_example_14/NopolExampleTest.java
+++ b/test-projects/src/test/java/nopol_examples/nopol_example_14/NopolExampleTest.java
@@ -1,0 +1,15 @@
+package nopol_examples.nopol_example_14;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class NopolExampleTest {
+
+	@Test
+	public void test1() {
+		NopolExample ex = new NopolExample();
+		assertEquals(1, ex.identity(1));
+	}
+
+}


### PR DESCRIPTION
`collectSpecifications` returns an empty list when synthesis is not possible (i.e., when there is no angelic value). This case is now reported accordingly.

"Not enough specifications" is now reported when a trivial patch would satisfy the available specifications.

The counter of statements with angelic values is updated accordingly. If there is only one spec for a statement with an angelic value, the final status will be `NO_SYNTHESIS` instead of `NO_ANGELIC_VALUE`.